### PR TITLE
Fix admin html page resolution on Cloudfront

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -202,6 +202,7 @@ jobs:
           name: Deploy to S3
           command: |
             aws s3 sync ../dist s3://${S3_SITE_BUCKET} --no-progress --delete
+            aws s3 cp ../dist/admin.html s3://${S3_SITE_BUCKET} --content-type 'text/html' --acl public-read
             aws cloudfront create-invalidation --distribution-id ${CF_DISTRIBUTION_ID} --paths "/*"
 
 workflows:


### PR DESCRIPTION
Navigating to /admin returns 404. Navigating to /admin.html returns admin page. This fixes this issue and doesn't require .html extension in the URL.