### PR TITLE
Reduce number of availability zones to 1

### DIFF
--- a/infrastructure/index.js
+++ b/infrastructure/index.js
@@ -31,7 +31,7 @@ if (isProd) {
 const vpc = new awsx.ec2.Vpc(
   `${PROJECT_NAME}-vpc`,
   {
-    numberOfAvailabilityZones: 2,
+    numberOfAvailabilityZones: 1,
     enableDnsHostnames: true,
     natGateways: { strategy: 'None' },
     subnetStrategy: 'Auto',


### PR DESCRIPTION
For dev purposes, we only need a basic setup and not a fully secure prod env. To save some money, we can drop to 1 AZ setup in dev env.